### PR TITLE
fix(*): only check for ISO 8601 date formats

### DIFF
--- a/src/SPObject.php
+++ b/src/SPObject.php
@@ -77,8 +77,8 @@ abstract class SPObject implements SPObjectInterface
      */
     protected function assign($property, $value)
     {
-        // convert any date format string to a Carbon object
-        if (strtotime($value) !== false) {
+        // convert ISO 8601 dates into Carbon objects
+        if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})?$/', $value) === 1) {
             $value = new Carbon($value);
         }
 


### PR DESCRIPTION
Using `strtotime()` to check for known date formats isn't such a good idea.
