### PR TITLE
[RFC] Fixes call to undefined method

### DIFF
--- a/src/SPFolder.php
+++ b/src/SPFolder.php
@@ -146,11 +146,7 @@ class SPFolder extends SPListObject implements SPItemInterface
     }
 
     /**
-     * Get URL
-     *
-     * @access  public
-     * @param   string $path Path to append to the URL
-     * @return  string
+     * {@inheritdoc}
      */
     public function getUrl($path = null)
     {

--- a/src/SPFolderInterface.php
+++ b/src/SPFolderInterface.php
@@ -27,10 +27,19 @@ interface SPFolderInterface extends SPRequesterInterface
      * Get Relative URL
      *
      * @access  public
-     * @param   string $path Path to append to the URL
+     * @param   string $path Path to append to the Relative URL
      * @return  string
      */
     public function getRelativeUrl($path = null);
+
+    /**
+     * Get URL
+     *
+     * @access  public
+     * @param   string $path Path to append to the URL
+     * @return  string
+     */
+    public function getUrl($path = null);
 
     /**
      * Is the folder writable?

--- a/src/SPList.php
+++ b/src/SPList.php
@@ -222,6 +222,14 @@ class SPList extends SPListObject
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getUrl($path = null)
+    {
+        return $this->site->getHostname($this->getRelativeUrl($path));
+    }
+
+    /**
      * Get List Description
      *
      * @access  public


### PR DESCRIPTION
```
Call to undefined method WeAreArchitect\SharePoint\SPList::getUrl() 
```

The `getUrl()` method is now part of the `SPFolderInterface`
